### PR TITLE
Add IsSupportedPlatform() Interface

### DIFF
--- a/src/Interface/ITextureDecoder.cs
+++ b/src/Interface/ITextureDecoder.cs
@@ -7,6 +7,7 @@ namespace Toolbox.Core
     public interface ITextureDecoder
     {
         bool CanEncode(TexFormat format);
+        bool IsSupportedPlatform();
         bool Decode(TexFormat format, byte[] input, int width, int height, out byte[] output);
         bool Encode(TexFormat format, byte[] input, int width, int height, out byte[] output);
     }

--- a/src/Textures/Decoders/ASTC.cs
+++ b/src/Textures/Decoders/ASTC.cs
@@ -13,6 +13,10 @@ namespace Toolbox.Core.Imaging
             return false;
         }
 
+        public bool IsSupportedPlatform() {
+            return true;
+        }
+
         public bool Decode(TexFormat format, byte[] input, int width, int height, out byte[] output)
         {
             output = null;

--- a/src/Textures/Decoders/BCN.cs
+++ b/src/Textures/Decoders/BCN.cs
@@ -12,6 +12,10 @@ namespace Toolbox.Core.Imaging
             return false;
         }
 
+        public bool IsSupportedPlatform() {
+            return true;
+        }
+
         public bool Decode(TexFormat format, byte[] input, int width, int height, out byte[] output)
         {
             output = null;

--- a/src/Textures/Decoders/RGBAPixelDecoder.cs
+++ b/src/Textures/Decoders/RGBAPixelDecoder.cs
@@ -13,6 +13,10 @@ namespace Toolbox.Core.Imaging
             return false;
         }
 
+        public bool IsSupportedPlatform() {
+            return true;
+        }
+
         /// Convert a 4-bit color component to 8 bit
         private static byte Convert1To8(byte value) {
             return (byte)(value * 255);


### PR DESCRIPTION
Currently the DirectXTexLibrary will run regardless of what platform you are trying to run TrackStudio on. This is problematic for LInux (and MacOS) platforms, as Track Studio would just crash when it tries to create the texture.